### PR TITLE
Fixed following error which doesn't appear in a normal game, but can be

### DIFF
--- a/CM_Browser.cs
+++ b/CM_Browser.cs
@@ -105,6 +105,12 @@ namespace CraftManager
         //**Event Hooks**//
 
         protected override void on_show(){            
+            //Set selected type (SPH or VAB) based on which editor we're in.
+            type_select(EditorDriver.editorFacility.ToString(), true);
+
+            //Add on focus event to trigger checking download queue 
+            GameEvents.OnAppFocus.Add(on_app_focus);
+
             stock_craft_loaded = false;
             show_transfer_indicator = false;
             CraftManager.status_info = "";

--- a/CraftManager.cs
+++ b/CraftManager.cs
@@ -42,7 +42,7 @@ namespace CraftManager
         internal static GUISkin alt_skin = null;
 
         //other
-        public static string ksp_root = Directory.GetParent(KSPUtil.ApplicationRootPath).FullName;
+        public static string ksp_root { get { return Directory.GetParent(KSPUtil.ApplicationRootPath).FullName; } }
         public static string status_info = "";
         
 

--- a/CraftManager.cs
+++ b/CraftManager.cs
@@ -42,11 +42,13 @@ namespace CraftManager
         internal static GUISkin alt_skin = null;
 
         //other
-        public static string ksp_root { get { return Directory.GetParent(KSPUtil.ApplicationRootPath).FullName; } }
+        static string appRootPath = "";
+        public static string ksp_root { get { return Directory.GetParent(appRootPath).FullName; } }
         public static string status_info = "";
         
 
         private void Awake(){
+            appRootPath = KSPUtil.ApplicationRootPath;
             settings = new CMSettings();
 
             bool using_toolbar = false;
@@ -74,7 +76,11 @@ namespace CraftManager
 
         //Bind events to add buttons to the toolbar
         private void add_main_icon_to_toolbar(){
+#if false
+            // This isn't necessary, entire class/gui will be destroyed when leaving the editor.
+            // This had a bad interaction with QuickHide, which hides the toolbar without leaving the editor
             ApplicationLauncher.Instance.AddOnHideCallback(this.toolbar_on_hide);     //bind events to close guis when toolbar hides
+#endif
             CraftManager.log("Adding main icon to toolbar");
             if(!CraftManager.main_ui_toolbar_button){
                 CraftManager.main_ui_toolbar_button = ApplicationLauncher.Instance.AddModApplication(
@@ -147,12 +153,15 @@ namespace CraftManager
             }
         }
 
+#if false
+        // Not needed, entire GUI will be removed upon exiting the editor
         //triggered when the application launcher hides, used to teardown open GUIs
         private void toolbar_on_hide(){
             if(CraftManager.main_ui){
                 GameObject.Destroy(CraftManager.main_ui);
             }
         }
+#endif
 
         internal static void log(string msg){
             Debug.Log("[CM] " + msg);
@@ -211,7 +220,7 @@ namespace CraftManager
     internal class Translate
     {
         internal static string this_string(string look_up){
-            if(look_up.Contains("#autoLOC")){
+            if(look_up != null && look_up.Contains("#autoLOC")){
                 string translated_name;
                 if(KSP.Localization.Localizer.TryGetStringByTag(look_up, out translated_name)){
                     look_up = translated_name;

--- a/LGGChangeLog.txt
+++ b/LGGChangeLog.txt
@@ -1,0 +1,20 @@
+Changelog
+
+	Fixed nullref caused by missing "description" or "ship" in the craft file
+	Fixed stock toolbar hiding (by Quickhide) causing screen to lock up.
+	Fixed issue #5, when changing from VAB to SPH or back, the default folder when opening mod now is set to the correct vessel directory
+	Fixed following error which doesn't appear in a normal game, but can be
+		seen when in a debug version of the game:
+
+		UnityException: get_dataPath is not allowed to be called from a
+		MonoBehaviour constructor (or instance field initializer), call it in
+		Awake or Start instead. Called from MonoBehaviour 'CraftManager' on game
+		object 'CraftManager'.
+		See "Script Serialization" page in the Unity Manual for further details.
+		at (wrapper managed-to-native) UnityEngine.Application.get_dataPath()
+		at KSPUtil.get_ApplicationRootPath () [0x0001d] in
+		<9d71e4043e394d78a6cf9193ad011698>:0
+		at CraftManager.CraftManager..cctor () [0x00049] in
+		<8b61a4f45bb64fb591febc58234adb97>:0
+		Rethrow as TypeInitializationException: The type initializer for
+		'CraftManager.CraftManager' threw an exception.


### PR DESCRIPTION
Fixed following error which doesn't appear in a normal game, but can be 
seen when in a debug version of the game:

UnityException: get_dataPath is not allowed to be called from a
MonoBehaviour constructor (or instance field initializer), call it in
Awake or Start instead. Called from MonoBehaviour 'CraftManager' on game
object 'CraftManager'.
See "Script Serialization" page in the Unity Manual for further details.
  at (wrapper managed-to-native) UnityEngine.Application.get_dataPath()
    at KSPUtil.get_ApplicationRootPath () [0x0001d] in
    <9d71e4043e394d78a6cf9193ad011698>:0
      at CraftManager.CraftManager..cctor () [0x00049] in
      <8b61a4f45bb64fb591febc58234adb97>:0
      Rethrow as TypeInitializationException: The type initializer for
      'CraftManager.CraftManager' threw an exception.